### PR TITLE
(fix) D3 bubble chart and historical_charge_event reports.

### DIFF
--- a/factories/reportHelpers.js
+++ b/factories/reportHelpers.js
@@ -1,11 +1,12 @@
 var moment = require( 'moment' );
-var Q = require( 'q' );
+var Q      = require( 'q' );
+var async  = require( 'async' );
+var models = require( '../models');
+var ekm    = require( './ekmFactory.js' );
+var csv    = require( './csvFactory');
 var station = require( '../models').station;
 var plug = require( '../models').plug;
 var charge_event = require( '../models').charge_event;
-var async     = require( 'async' );
-var ekm = require( './ekmFactory.js' );
-var csv = require( './csvFactory');
 
 exports.orderByKin = function( collection ) {
   collection.sort(function( a, b ) {
@@ -274,7 +275,7 @@ exports.chargesOverLastThirtyDaysForOneStation = function( oneStation ) {
     order: [ [ 'time_start', 'ASC' ] ]
   };
 
-  return charge_event.findAll( where )
+  return models.historical_charge_event.findAll( where )
   .then(function( eventsForStation ) {
     var dataForCSV = {
       kin: oneStation.kin,
@@ -339,6 +340,7 @@ exports.chargesOverLastThirtyDaysForOneStation = function( oneStation ) {
       dataForCSV.medianGallonsPerEvent = consumerNumbersMedian.gallons;
     }
 
+    console.log( 'dataForCSV', dataForCSV )
     return dataForCSV;
   });
 };

--- a/factories/reportHelpers.js
+++ b/factories/reportHelpers.js
@@ -227,7 +227,7 @@ exports.chargeEventsOverTime = function( where, timePeriod ) {
   };
   var periods = [];
 
-  return charge_event.findAll( query )
+  return models.historical_charge_event.findAll( query )
   .then(function( chargeEvents ) {
     // set the first 30-min period
     var currentPeriod = moment( chargeEvents[ 0 ].time_start ).add( timeNum, timeUnit );
@@ -340,7 +340,6 @@ exports.chargesOverLastThirtyDaysForOneStation = function( oneStation ) {
       dataForCSV.medianGallonsPerEvent = consumerNumbersMedian.gallons;
     }
 
-    console.log( 'dataForCSV', dataForCSV )
     return dataForCSV;
   });
 };

--- a/factories/reports/eventsOverTime.js
+++ b/factories/reports/eventsOverTime.js
@@ -1,9 +1,9 @@
-
+var moment       = require( 'moment' );
 var charge_event = require( '../../models' ).charge_event;
-var station = require( '../../models' ).station;
-var moment = require( 'moment' );
-moment().format();
-var helper = require( '../reportHelpers' );
+var station      = require( '../../models' ).station;
+var helper       = require( '../reportHelpers' );
+var models       = require( '../../models' );
+
 
 exports.countNumberOfDaysWithoutData = function( firstDayWithCharge, nextDayWithCharge, kwh ) {
   var nulls = {};
@@ -133,7 +133,7 @@ exports.dataOverThirtyDays = function() {
     }
 
     // get all closed charge events from the last 30 days
-    return charge_event.findAll( { where: { time_start: { $gt: thirtyDaysAgo.toDate() } , time_stop: { $ne: null } }, order: 'time_start', raw: true } );
+    return models.historical_charge_event.findAll( { where: { time_start: { $gt: thirtyDaysAgo.toDate() } , time_stop: { $ne: null } }, order: 'time_start', raw: true } );
   })
   .then(function ( chargeEvents ) {
 

--- a/test/factories/reportHelpers.spec.js
+++ b/test/factories/reportHelpers.spec.js
@@ -1,11 +1,10 @@
+var Q             = require( 'q' );
+var async         = require( 'async' );
+var moment        = require( 'moment' );
+var db            = require( '../../models' );
 var reportHelpers = require( '../../factories/reportHelpers.js' );
-var Q = require( 'q' );
-var db = require( '../../models/index.js' );
-var csv = require( '../../factories/csvFactory.js' );
-var moment = require( 'moment' );
-moment().format();
-var async = require( 'async' );
-var ekmFactory = require( '../../factories/ekmFactory.js' );
+var csv           = require( '../../factories/csvFactory.js' );
+var ekmFactory    = require( '../../factories/ekmFactory.js' );
 
 module.exports = function() {
   describe('reportHelpers.js', function() {
@@ -343,7 +342,7 @@ module.exports = function() {
       beforeEach(function() {
         timePeriod = [ 1, 'days' ];
         findChargeEvents = Q.defer();
-        spyOn( db.charge_event, 'findAll' ).andReturn( findChargeEvents.promise );
+        spyOn( db.historical_charge_event, 'findAll' ).andReturn( findChargeEvents.promise );
       });
 
       it('should be defined as a function', function() {
@@ -359,28 +358,37 @@ module.exports = function() {
       it('should find all charge events', function( done ) {
         findChargeEvents.reject();
         chargeEventsOverTime( null, timePeriod )
+        .then(function( result ) {
+          expect( result ).toBeUndefined();
+        })
         .catch(function() {
-          expect( db.charge_event.findAll ).toHaveBeenCalled();
-          done();
-        });
+          expect( db.historical_charge_event.findAll ).toHaveBeenCalled();
+        })
+        .done( done );
       });
 
       it('should construct query user-passed WHERE', function( done ) {
         findChargeEvents.reject();
         chargeEventsOverTime( { where: { id: 1 } }, timePeriod )
+        .then(function( result ) {
+          expect( result ).toBeUndefined();
+        })
         .catch(function() {
-          expect( db.charge_event.findAll ).toHaveBeenCalledWith( { where: { id: 1, time_stop: { $ne: null } }, order: 'id', raw: true } );
-          done();
-        });
+          expect( db.historical_charge_event.findAll ).toHaveBeenCalledWith( { where: { id: 1, time_stop: { $ne: null } }, order: 'id', raw: true } );
+        })
+        .done( done );
       });
 
       it('should construct query if one is not provided', function( done ) {
         findChargeEvents.reject();
         chargeEventsOverTime( null, timePeriod )
+        .then(function( result ) {
+          expect( result ).toBeUndefined();
+        })
         .catch(function() {
-          expect( db.charge_event.findAll ).toHaveBeenCalledWith( { where: { time_stop: { $ne: null } }, order: 'id', raw: true } );
-          done();
-        });
+          expect( db.historical_charge_event.findAll ).toHaveBeenCalledWith( { where: { time_stop: { $ne: null } }, order: 'id', raw: true } );
+        })
+        .done( done );
       });
 
       it('should return array with accumulators over the time interval', function( done ) {
@@ -405,12 +413,11 @@ module.exports = function() {
           expect( result[ 0 ] ).toEqual( { time: moment( '2015 05 17', 'YYYY MM DD' ).toDate(), events: 1, kwh: 5.2 } );
           expect( result[ 1 ] ).toEqual( { time: moment( '2015 05 18', 'YYYY MM DD' ).toDate(), events: 3, kwh: 8.8 } );
           expect( result[ 2 ] ).toEqual( { time: moment( '2015 05 20', 'YYYY MM DD' ).toDate(), events: 4, kwh: 18.8 } );
-          done();
         })
         .catch(function( error ) {
-          expect( error ).not.toBeDefined();
-          done();
-        });
+          expect( error ).toBeUndefined();
+        })
+        .done( done );
       });
     });
 
@@ -443,7 +450,7 @@ module.exports = function() {
 
       beforeEach(function() {
         findChargeEvents = Q.defer();
-        spyOn( db.charge_event, 'findAll' ).andReturn( findChargeEvents.promise );
+        spyOn( db.historical_charge_event, 'findAll' ).andReturn( findChargeEvents.promise );
         spyOn( reportHelpers, 'countChargesAndDuration' ).andReturn( averagesAndMedians );
         spyOn( reportHelpers, 'convertKwhToConsumerEquivalents' ).andReturn( conversions );
       });
@@ -461,19 +468,22 @@ module.exports = function() {
       it('should find all charge events for last 30 days', function( done ) {
         findChargeEvents.reject();
         chargesOverLastThirtyDaysForOneStation( station1 )
+        .then(function( result ) {
+          expect( result ).toBeUndefined();
+        })
         .catch(function() {
-          expect( db.charge_event.findAll ).toHaveBeenCalled();
-          expect( db.charge_event.findAll.calls[ 0 ].args[ 0 ].hasOwnProperty( 'where' ) ).toBe( true );
-          expect( db.charge_event.findAll.calls[ 0 ].args[ 0 ].where.station_id ).toBe( 1 );
+          expect( db.historical_charge_event.findAll ).toHaveBeenCalled();
+          expect( db.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].hasOwnProperty( 'where' ) ).toBe( true );
+          expect( db.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].where.station_id ).toBe( 1 );
           // can't really test date directly
-          expect( db.charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_start[ '$gt' ] ).toBeDefined();
-          expect( db.charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_stop[ '$ne' ] ).toBe( null );
-          expect( db.charge_event.findAll.calls[ 0 ].args[ 0 ].hasOwnProperty( 'raw' ) ).toBe( true );
-          expect( db.charge_event.findAll.calls[ 0 ].args[ 0 ].raw ).toBe( true );
-          expect( db.charge_event.findAll.calls[ 0 ].args[ 0 ].hasOwnProperty( 'order' ) ).toBe( true );
-          expect( db.charge_event.findAll.calls[ 0 ].args[ 0 ].order ).toEqual( [ [ 'time_start', 'ASC' ] ] );
-          done();
-        });
+          expect( db.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_start[ '$gt' ] ).toBeDefined();
+          expect( db.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_stop[ '$ne' ] ).toBe( null );
+          expect( db.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].hasOwnProperty( 'raw' ) ).toBe( true );
+          expect( db.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].raw ).toBe( true );
+          expect( db.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].hasOwnProperty( 'order' ) ).toBe( true );
+          expect( db.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].order ).toEqual( [ [ 'time_start', 'ASC' ] ] );
+        })
+        .done( done );
       });
 
       it('should make various calcs and return object for CSV', function( done ) {

--- a/test/factories/reports/eventsOverTime.spec.js
+++ b/test/factories/reports/eventsOverTime.spec.js
@@ -1,10 +1,9 @@
-var models = require( '../../../models' );
+var Q            = require( 'q' );
+var moment       = require( 'moment' );
+var models       = require( '../../../models' );
 var charge_event = models.charge_event;
-var station = models.station;
-var time = require( '../../../factories/reports/eventsOverTime.js' );
-var Q = require( 'q' );
-var moment = require( 'moment' );
-moment().format();
+var station      = models.station;
+var time         = require( '../../../factories/reports/eventsOverTime.js' );
 
 module.exports = function() {
   describe('eventsOverTime.js', function() {
@@ -244,7 +243,7 @@ module.exports = function() {
         findStations = Q.defer();
         findChargeEvents = Q.defer();
         spyOn( station, 'findAll' ).andReturn( findStations.promise );
-        spyOn( charge_event, 'findAll' ).andReturn( findChargeEvents.promise );
+        spyOn( models.historical_charge_event, 'findAll' ).andReturn( findChargeEvents.promise );
       });
 
       it('should be defined as a function', function() {
@@ -260,25 +259,31 @@ module.exports = function() {
       it('should find all stations', function( done ) {
         findStations.reject();
         dataOverThirtyDays()
+        .then(function( result ) {
+          expect( result ).toBeUndefined();
+        })
         .catch(function() {
           expect( station.findAll ).toHaveBeenCalled();
           expect( station.findAll ).toHaveBeenCalledWith( { raw: true } );
-          done();
-        });
+        })
+        .done( done );
       });
 
       it('should find all charge events in last 30 days', function( done ) {
         findStations.resolve( [] );
         findChargeEvents.reject();
         dataOverThirtyDays()
+        .then(function( result ) {
+          expect( result ).toBeUndefined();
+        })
         .catch(function() {
-          expect( charge_event.findAll ).toHaveBeenCalled();
-          expect( charge_event.findAll.calls[ 0 ].args[ 0 ].where ).toBeDefined();
-          expect( charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_start ).toBeDefined();
-          expect( charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_start[ '$gt' ] ).toBeDefined();
-          expect( charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_stop ).toEqual( { $ne: null } );
-          done();
-        });
+          expect( models.historical_charge_event.findAll ).toHaveBeenCalled();
+          expect( models.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].where ).toBeDefined();
+          expect( models.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_start ).toBeDefined();
+          expect( models.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_start[ '$gt' ] ).toBeDefined();
+          expect( models.historical_charge_event.findAll.calls[ 0 ].args[ 0 ].where.time_stop ).toEqual( { $ne: null } );
+        })
+        .done( done );
       });
 
       it('should return stations with cumulative 30-day data', function( done ) {
@@ -319,12 +324,11 @@ module.exports = function() {
           expect( result[ '2' ].session_lengths ).toEqual( [ 65 ] );
           expect( result[ '2' ].charge_events.length ).toBe( 30 );
           expect( result[ '2' ].charge_events ).toEqual( [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 ] );
-          done();
         })
         .catch(function( error ) {
           expect( error ).not.toBeDefined();
-          done();
-        });
+        })
+        .done( done );
       });
 
       it('should delete stations which have no charge events', function( done ) {
@@ -349,12 +353,11 @@ module.exports = function() {
           expect( result[ '1' ].time_spent_charging ).toBe( 210 );
           expect( result.hasOwnProperty( '2' ) ).toBe( false );
           expect( result.hasOwnProperty( '3' ) ).toBe( false );
-          done();
         })
         .catch(function( error ) {
           expect( error ).not.toBeDefined();
-          done();
-        });
+        })
+        .done( done );
       });
 
       it('should throw error if network is not correct', function( done ) {
@@ -367,12 +370,11 @@ module.exports = function() {
         dataOverThirtyDays()
         .then(function( result ) {
           expect( result ).not.toBeDefined();
-          done();
         })
         .catch(function( error ) {
           expect( error.message ).toBe( 'Network (OC) not found in global median data object, eventOverTime.dataOverThirtyDays.' );
-          done();
-        });
+        })
+        .done( done );
       });
     });
   });


### PR DESCRIPTION
![MY BUBBLES!](https://67.media.tumblr.com/8d6bfccb7d2b2b8bdff1af5644c0e888/tumblr_inline_ne0h7wX8eg1qb0ee7.gif)

## Summary of Changes
Many of these changes simply swap the charge_event table for historical_charge_events. Also updated tests accordingly and refactored them with better error-handling.

Backend fixes to endpoints for Station-Manager:
- Abdellah's Historical Charge Event report
- 30 Day media sales usage report for users with mediaSales role in Station-Manager
- D3 30-day bubble chart
![screen shot 2016-12-01 at 8 27 41 pm](https://cloud.githubusercontent.com/assets/8163408/20823437/d03aca40-b808-11e6-8f47-a249857de7e2.png)