### PR TITLE
(feat) Added data dumps endpoints for Abdellah to access via Station-Manager.

### DIFF
--- a/controllers/protected/reports.protectedController.js
+++ b/controllers/protected/reports.protectedController.js
@@ -345,33 +345,16 @@ module.exports = exports = {
     });
   },
   exportHistoricalChargeEventDataAsCsv: function( req, res ) {
-    // var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
-    // var fieldNames = [ 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
-
-    // station.findAll( { order: [ 'kin' ], raw: true } )
-    // .then(function( stations ) {
-    //   for ( var i = 0; i < stations.length; i++ ) {
-    //     var oneStation = stations[ i ];
-    //     if ( oneStation.location_gps ) {
-    //       // make gps a string
-    //       stations[ i ].location_gps = oneStation.location_gps.toString();
-    //       oneStation = stations[ i ];
-    //     }
-
-    //     for ( var key in oneStation ) {
-    //       if ( oneStation[ key ] === null ) {
-    //         oneStation[ key ] = '';
-    //       }
-    //     }
-    //   }
-    //   return csv.generateCSV( stations, fields, fieldNames );
-    // })
-    // .then(function( csv ) {
-    //   res.send( csv );
-    // })
-    // .catch(function( error ) {
+    models.historical_charge_event.findAll( { order: [ 'id' ], raw: true } )
+    .then(function( chargeEvents ) {
+      return csv.generateCSV( chargeEvents, null, null );
+    })
+    .then(function( csv ) {
+      res.send( csv );
+    })
+    .catch(function( error ) {
       res.status( 500 ).send( error.message );
-    // });
+    });
   },
   generateListOfWallmounts: function( req, res ) {
     var type = req.params.output;

--- a/controllers/protected/reports.protectedController.js
+++ b/controllers/protected/reports.protectedController.js
@@ -289,8 +289,8 @@ module.exports = exports = {
     });
   },
   exportStationDataAsCsv: function( req, res ) {
-    var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
-    var fieldNames = [ 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
+    var fields = [ 'id', 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
+    var fieldNames = [ 'ID', 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
 
     station.findAll( { order: [ 'kin' ], raw: true } )
     .then(function( stations ) {

--- a/controllers/protected/reports.protectedController.js
+++ b/controllers/protected/reports.protectedController.js
@@ -317,6 +317,93 @@ module.exports = exports = {
       res.status( 500 ).send( error.message );
     });
   },
+  exportPlugDataAsCsv: function( req, res ) {
+    // var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
+    // var fieldNames = [ 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
+
+    // station.findAll( { order: [ 'kin' ], raw: true } )
+    // .then(function( stations ) {
+    //   for ( var i = 0; i < stations.length; i++ ) {
+    //     var oneStation = stations[ i ];
+    //     if ( oneStation.location_gps ) {
+    //       // make gps a string
+    //       stations[ i ].location_gps = oneStation.location_gps.toString();
+    //       oneStation = stations[ i ];
+    //     }
+
+    //     for ( var key in oneStation ) {
+    //       if ( oneStation[ key ] === null ) {
+    //         oneStation[ key ] = '';
+    //       }
+    //     }
+    //   }
+    //   return csv.generateCSV( stations, fields, fieldNames );
+    // })
+    // .then(function( csv ) {
+    //   res.send( csv );
+    // })
+    // .catch(function( error ) {
+      res.status( 500 ).send( error.message );
+    // });
+  },
+  exportChargeEventDataAsCsv: function( req, res ) {
+    // var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
+    // var fieldNames = [ 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
+
+    // station.findAll( { order: [ 'kin' ], raw: true } )
+    // .then(function( stations ) {
+    //   for ( var i = 0; i < stations.length; i++ ) {
+    //     var oneStation = stations[ i ];
+    //     if ( oneStation.location_gps ) {
+    //       // make gps a string
+    //       stations[ i ].location_gps = oneStation.location_gps.toString();
+    //       oneStation = stations[ i ];
+    //     }
+
+    //     for ( var key in oneStation ) {
+    //       if ( oneStation[ key ] === null ) {
+    //         oneStation[ key ] = '';
+    //       }
+    //     }
+    //   }
+    //   return csv.generateCSV( stations, fields, fieldNames );
+    // })
+    // .then(function( csv ) {
+    //   res.send( csv );
+    // })
+    // .catch(function( error ) {
+      res.status( 500 ).send( error.message );
+    // });
+  },
+  exportHistoricalChargeEventDataAsCsv: function( req, res ) {
+    // var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
+    // var fieldNames = [ 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
+
+    // station.findAll( { order: [ 'kin' ], raw: true } )
+    // .then(function( stations ) {
+    //   for ( var i = 0; i < stations.length; i++ ) {
+    //     var oneStation = stations[ i ];
+    //     if ( oneStation.location_gps ) {
+    //       // make gps a string
+    //       stations[ i ].location_gps = oneStation.location_gps.toString();
+    //       oneStation = stations[ i ];
+    //     }
+
+    //     for ( var key in oneStation ) {
+    //       if ( oneStation[ key ] === null ) {
+    //         oneStation[ key ] = '';
+    //       }
+    //     }
+    //   }
+    //   return csv.generateCSV( stations, fields, fieldNames );
+    // })
+    // .then(function( csv ) {
+    //   res.send( csv );
+    // })
+    // .catch(function( error ) {
+      res.status( 500 ).send( error.message );
+    // });
+  },
   generateListOfWallmounts: function( req, res ) {
     var type = req.params.output;
     var fields = [ 'kin', 'location', 'location_address', 'network' ];

--- a/controllers/protected/reports.protectedController.js
+++ b/controllers/protected/reports.protectedController.js
@@ -317,7 +317,6 @@ module.exports = exports = {
       res.status( 500 ).send( error.message );
     });
   },
-  // add id to station
   exportPlugDataAsCsv: function( req, res ) {
     var fields = [ 'id', 'number_on_station', 'install_date', 'connector_type', 'charger_type', 'max_amps', 'ekm_omnimeter_serial', 'meter_status', 'meter_status_message', 'in_use', 'cumulative_kwh', 'station_id' ];
     var fieldNames = [ 'ID', 'Number on Station', 'Install Date', 'Connector', 'Charger Type (level)', 'Max Amps', 'Omnimeter Serial Number', 'Meter Status', 'Meter Status Message', 'In Use', 'Cumulative kWh', 'Station ID' ];
@@ -334,33 +333,16 @@ module.exports = exports = {
     });
   },
   exportChargeEventDataAsCsv: function( req, res ) {
-    // var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
-    // var fieldNames = [ 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
-
-    // station.findAll( { order: [ 'kin' ], raw: true } )
-    // .then(function( stations ) {
-    //   for ( var i = 0; i < stations.length; i++ ) {
-    //     var oneStation = stations[ i ];
-    //     if ( oneStation.location_gps ) {
-    //       // make gps a string
-    //       stations[ i ].location_gps = oneStation.location_gps.toString();
-    //       oneStation = stations[ i ];
-    //     }
-
-    //     for ( var key in oneStation ) {
-    //       if ( oneStation[ key ] === null ) {
-    //         oneStation[ key ] = '';
-    //       }
-    //     }
-    //   }
-    //   return csv.generateCSV( stations, fields, fieldNames );
-    // })
-    // .then(function( csv ) {
-    //   res.send( csv );
-    // })
-    // .catch(function( error ) {
+    models.charge_event.findAll( { order: [ 'id' ], raw: true } )
+    .then(function( chargeEvents ) {
+      return csv.generateCSV( chargeEvents, null, null );
+    })
+    .then(function( csv ) {
+      res.send( csv );
+    })
+    .catch(function( error ) {
       res.status( 500 ).send( error.message );
-    // });
+    });
   },
   exportHistoricalChargeEventDataAsCsv: function( req, res ) {
     // var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];

--- a/controllers/protected/reports.protectedController.js
+++ b/controllers/protected/reports.protectedController.js
@@ -317,34 +317,21 @@ module.exports = exports = {
       res.status( 500 ).send( error.message );
     });
   },
+  // add id to station
   exportPlugDataAsCsv: function( req, res ) {
-    // var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
-    // var fieldNames = [ 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
+    var fields = [ 'id', 'number_on_station', 'install_date', 'connector_type', 'charger_type', 'max_amps', 'ekm_omnimeter_serial', 'meter_status', 'meter_status_message', 'in_use', 'cumulative_kwh', 'station_id' ];
+    var fieldNames = [ 'ID', 'Number on Station', 'Install Date', 'Connector', 'Charger Type (level)', 'Max Amps', 'Omnimeter Serial Number', 'Meter Status', 'Meter Status Message', 'In Use', 'Cumulative kWh', 'Station ID' ];
 
-    // station.findAll( { order: [ 'kin' ], raw: true } )
-    // .then(function( stations ) {
-    //   for ( var i = 0; i < stations.length; i++ ) {
-    //     var oneStation = stations[ i ];
-    //     if ( oneStation.location_gps ) {
-    //       // make gps a string
-    //       stations[ i ].location_gps = oneStation.location_gps.toString();
-    //       oneStation = stations[ i ];
-    //     }
-
-    //     for ( var key in oneStation ) {
-    //       if ( oneStation[ key ] === null ) {
-    //         oneStation[ key ] = '';
-    //       }
-    //     }
-    //   }
-    //   return csv.generateCSV( stations, fields, fieldNames );
-    // })
-    // .then(function( csv ) {
-    //   res.send( csv );
-    // })
-    // .catch(function( error ) {
+    models.plug.findAll( { order: [ 'id' ], raw: true } )
+    .then(function( plugs ) {
+      return csv.generateCSV( plugs, fields, fieldNames );
+    })
+    .then(function( csv ) {
+      res.send( csv );
+    })
+    .catch(function( error ) {
       res.status( 500 ).send( error.message );
-    // });
+    });
   },
   exportChargeEventDataAsCsv: function( req, res ) {
     // var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];

--- a/routes/protected/protectedReportRoutes.js
+++ b/routes/protected/protectedReportRoutes.js
@@ -37,6 +37,18 @@ router.route( '/wrongCoordinates/:output' )
 router.route( '/downloadStations/CSV' )
   .get( controller.exportStationDataAsCsv );
 
+// for http://www.baseurl.com/protected/reports/downloadPlugs/CSV
+router.route( '/downloadPlugs/CSV' )
+  .get( controller.exportPlugDataAsCsv );
+
+// for http://www.baseurl.com/protected/reports/downloadChargeEvents/CSV
+router.route( '/downloadChargeEvents/CSV' )
+  .get( controller.exportChargeEventDataAsCsv );
+
+// for http://www.baseurl.com/protected/reports/downloadHistoricalChargeEvents/CSV
+router.route( '/downloadHistoricalChargeEvents/CSV' )
+  .get( controller.exportHistoricalChargeEventDataAsCsv );
+
 // for http://www.baseurl.com/protected/reports/chargeEventsOverTime/CSV
 router.route( '/chargeEventsOverTime/CSV' )
   .get( controller.getChargeDataOverTime );

--- a/test/controllers/protected/apiTests/reports.protectedController.spec.js
+++ b/test/controllers/protected/apiTests/reports.protectedController.spec.js
@@ -1084,6 +1084,83 @@ module.exports = function() {
           });
         });
       });
+
+      describe('reports/downloadHistoricalChargeEvents/CSV', function() {
+        var route = '/protected/reports/downloadHistoricalChargeEvents/CSV';
+
+        describe('GET', function() {
+          var findAllEvents, generateCSV;
+
+          beforeEach(function() {
+            findAllEvents = Q.defer();
+            generateCSV = Q.defer();
+            spyOn( models.historical_charge_event, 'findAll' ).andReturn( findAllEvents.promise );
+            spyOn( csv, 'generateCSV' ).andReturn( generateCSV.promise );
+          });
+
+          it('should be a defined route (not 404)', function( done ) {
+            findAllEvents.reject( new Error( 'Test' ) );
+            supertest.get( route )
+            .set( 'Authorization', 'Bearer ' + token )
+            .expect(function( res ) {
+              expect( res.statusCode ).not.toBe( 404 );
+            })
+            .end( done );
+          });
+
+          it('should 404 for Web endpoint', function( done ) {
+            route = '/protected/reports/downloadHistoricalChargeEvents/Web';
+            findAllEvents.reject( new Error( 'Test' ) );
+            supertest.get( route )
+            .set( 'Authorization', 'Bearer ' + token )
+            .expect( 404 )
+            .expect(function( res ) {
+              route = '/protected/reports/downloadHistoricalChargeEvents/CSV';
+            })
+            .end( done );
+          });
+
+          it('should generate CSV after manipulating data', function( done ) {
+            var events = [ { id: 1, kwh: 1.0 }, { id: 2, kwh: 2.7 } ];
+            findAllEvents.resolve( events );
+            generateCSV.reject( new Error( 'Test' ) );
+
+            supertest.get( route )
+            .set( 'Authorization', 'Bearer ' + token )
+            .expect(function( res ) {
+              expect( csv.generateCSV ).toHaveBeenCalled();
+              expect( csv.generateCSV ).toHaveBeenCalledWith( events, null, null );
+            })
+            .end( done );
+          });
+
+          it('should send CSV', function( done ) {
+            var events = [ { id: 1, kwh: 1.0 }, { id: 2, kwh: 2.7 } ];
+            findAllEvents.resolve( events );
+            generateCSV.resolve( 'CSV' );
+
+            supertest.get( route )
+            .set( 'Authorization', 'Bearer ' + token )
+            .expect( 200 )
+            .expect( 'Content-Type', /text/ )
+            .expect( 'CSV' )
+            .end( done );
+          });
+
+          it('should return 500 failure for error', function( done ) {
+            findAllEvents.reject( new Error( 'Test' ) );
+            supertest.get( route )
+            .set( 'Authorization', 'Bearer ' + token )
+            .expect( 500 )
+            .expect( 'Test' )
+            .expect( 'Content-Type', /text/ )
+            .expect(function( res ) {
+              expect( models.historical_charge_event.findAll ).toHaveBeenCalled();
+            })
+            .end( done );
+          });
+        });
+      });
     });
 
     describe('MEDIA SALES', function() {

--- a/test/controllers/protected/apiTests/reports.protectedController.spec.js
+++ b/test/controllers/protected/apiTests/reports.protectedController.spec.js
@@ -886,8 +886,8 @@ module.exports = function() {
           });
 
           it('should generate CSV after manipulating data', function( done ) {
-            var fields = [ 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
-            var fieldNames = [ 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
+            var fields = [ 'id', 'kin', 'location', 'location_address', 'location_gps', 'network', 'install_date', 'ekm_push_mac', 'sim_card', 'cumulative_kwh' ];
+            var fieldNames = [ 'ID', 'KIN', 'Location', 'Address', 'GPS', 'Network', 'Install Date', 'Push MAC', 'SIM card', 'Meter Reading (kWh)' ];
             var stations = [ { location_gps: [ 1, 2 ], location: null }, { location_gps: null, location: 'Home' } ];
             findAllStations.resolve( stations );
             generateCSV.reject( new Error( 'Test' ) );


### PR DESCRIPTION
Added the following routes and accociated controllers:
`http://www.baseurl.com/protected/reports/downloadPlugs/CSV`
`http://www.baseurl.com/protected/reports/downloadChargeEvents/CSV`
`http://www.baseurl.com/protected/reports/downloadHistoricalChargeEvents/CSV`

These endpoints dump each of their respective tables into (sometimes large) CSVs and return them to the client.

Tested the new routes. Overall code coverage at 89.39%.